### PR TITLE
Upgrade Fresh to 1.3

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -13,14 +13,22 @@
   },
   "imports": {
     "@/": "./",
-    "$fresh/": "https://deno.land/x/fresh@1.2.0/",
+    "$fresh/": "https://deno.land/x/fresh@1.3.1/",
     "preact": "https://esm.sh/preact@10.15.1",
     "preact/": "https://esm.sh/preact@10.15.1/",
-    "preact-render-to-string": "https://esm.sh/*preact-render-to-string@6.1.0",
+    "preact-render-to-string": "https://esm.sh/*preact-render-to-string@6.2.0",
     "@preact/signals": "https://esm.sh/*@preact/signals@1.1.3",
     "@preact/signals-core": "https://esm.sh/*@preact/signals-core@1.2.3",
     "$std/": "https://deno.land/std@0.187.0/",
     "@supabase/auth-helpers-shared": "https://esm.sh/@supabase/auth-helpers-shared@0.3.4?target=es2022",
     "@supabase/supabase-js": "https://esm.sh/@supabase/supabase-js@2.21.0"
+  },
+  "lint": {
+    "rules": {
+      "tags": [
+        "fresh",
+        "recommended"
+      ]
+    }
   }
 }


### PR DESCRIPTION
How to update Fresh: https://fresh.deno.dev/docs/concepts/updating

Updates:

- [Async Route Components](https://deno.com/blog/fresh-1.3#async-route-components)
- [Adding routes and/or middlewares from plugins](https://deno.com/blog/fresh-1.3#adding-routes-andor-middlewares-from-plugins)
- [500 error template fallback](https://deno.com/blog/fresh-1.3#500-error-template-fallback)
- [Error Boundaries](https://deno.com/blog/fresh-1.3#error-boundaries)
- [Export multiple islands in the same file](https://deno.com/blog/fresh-1.3#export-multiple-islands-in-the-same-file)
- [Fresh linting rules](https://deno.com/blog/fresh-1.3#fresh-linting-rules)
- [Support for Deno.serve](https://deno.com/blog/fresh-1.3#support-for-denoserve)
- [More quality of life improvements](https://deno.com/blog/fresh-1.3#more-quality-of-life-improvements)

More on these changes at https://deno.com/blog/fresh-1.3